### PR TITLE
Remove rails dependancy

### DIFF
--- a/fastapi.gemspec
+++ b/fastapi.gemspec
@@ -13,7 +13,8 @@ Gem::Specification.new do |s|
   s.license       = 'MIT'
 
   s.add_runtime_dependency 'oj', '~> 2.9.9'
-  s.add_runtime_dependency 'rails', '>= 3.2.0'
+  s.add_runtime_dependency 'activerecord', '> 3.2'
+  s.add_runtime_dependency 'activesupport', '> 3.2'
 
   s.required_ruby_version = '>= 1.9.3'
 


### PR DESCRIPTION
- IMO, we don't need all the rails library
- We just need activerecord and activesupport