### PR TITLE
Adding ability to specify 'all' attributes using symbol :all.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,20 @@ class Bucket < ActiveRecord::Base
   has_many :marbles
 
   # A "standard interface" is a list of user-exposed fields for the endpoint
+  fastapi_standard_interface :all
+
+end
+```
+
+You can also enumerate each field you'd like to add to the interface:
+
+```ruby
+class Bucket < ActiveRecord::Base
+
+  belongs_to :person
+  has_many :marbles
+
+  # adding the fields by providing an array of symbols
   fastapi_standard_interface [
     :id,
     :color,
@@ -120,24 +134,18 @@ class Person < ActiveRecord::Base
   #   endpoint... we use a special setting indicating
   #   which fields to use if Person happens to be nested.
 
-  # You can NOT include dependent fields here. (belongs_to, has_many)
+  # Dependent fields will not be included here. (belongs_to, has_many)
   #   This is a hard-and-fast FastAPI rule that prevents overly
   #   complex nesting scenarios.
 
-  fastapi_standard_interface_nested [
-    :id,
-    :name,
-    :gender,
-    :age
-  ]
-
+  fastapi_standard_interface_nested :all
 end
 ```
 
 Keep in mind that this will only affect the cases where `Person` is a nested
 object.
 
-If we wanted to expose a top-level `Person` api endpoint, we would use
+If we wanted to expose a top-level `Person` API endpoint, we would use
 `fastapi_standard_interface` as well.
 
 Finally, we must modify our `Marble` model in the same way:
@@ -145,11 +153,7 @@ Finally, we must modify our `Marble` model in the same way:
 ```ruby
 class Marble < ActiveRecord::Base
 
-  fastapi_standard_interface_nested [
-    :id,
-    :color,
-    :radius
-  ]
+  fastapi_standard_interface_nested :all
 
 end
 ```
@@ -231,24 +235,39 @@ FastAPI has four core components:
 ### ClassMethods
 
 #### fastapi_standard_interface
+Has two method signatures that are used to set the standard interface
+for the top level of a FastAPI response.
+
+`fastapi_standard_interface( :all, { except: [], timestamps: false, foreign_keys: false, associations: true } )`
+
+Includes attributes and associations for the model. Use the options hash
+if you need to further specify which fields are included. By default, timestamps
+and foreign keys are not included, but associated models are.
+
 `fastapi_standard_interface( fields [Array] )`
 
-Sets the standard interface for the top level of a fastapi response.
 Can use any available fields for the model, or `belongs_to` and `has_many`
 associations. Be sure to use the correct word form (singular vs. plural).
 
 #### fastapi_standard_interface_nested
+Has two method signatures that are used to set the standard interface for the second
+level of a FastAPI response (nested). Will be referred to whenever this model is
+found nested in another API response. *Does not support associations*.
+
+`fastapi_standard_interface_nested( :all, { except: [], timestamps: false, foreign_keys: false } )`
+
+Includes attributes for the model. Use the options hash if you need to
+further specify which fields are included. By default, timestamps and
+foreign keys are not included.
+
 `fastapi_standard_interface_nested( fields [Array] )`
 
-Sets the standard interface for the second level of a fastapi response
-(nested). Will be referred to whenever this model is found nested in another
-API response. Can use any available fields for the model, *does not support
-associations*.
+Can use any available fields for the model.
 
 #### fastapi_default_filters
 `fastapi_default_filters( filters [Hash] )`
 
-Sets any default filters for the top level fastapi response. Will be
+Sets any default filters for the top level FastAPI response. Will be
 overridden if the same filter keys are provided when calling `.filter` on
 a FastAPI instance. See *Filters* section for more information on available
 filters.

--- a/lib/fastapi/active_record_extension.rb
+++ b/lib/fastapi/active_record_extension.rb
@@ -24,7 +24,7 @@ module FastAPIExtension
     # @return [Array] the same array of fields
     def fastapi_standard_interface_nested(fields, options = {})
       if fields == :all
-        @fastapi_fields_sub = attributes(options.merge({associations: false}))
+        @fastapi_fields_sub = attributes(options.merge({ associations: false }))
       else
         @fastapi_fields_sub = fields
       end

--- a/lib/fastapi/active_record_extension.rb
+++ b/lib/fastapi/active_record_extension.rb
@@ -6,10 +6,15 @@ module FastAPIExtension
 
   module ClassMethods
 
-    # Used to set the standard interface for the top level of a fastapi response
+    # Set the standard interface for the top level of a FastAPI response.
     #
-    # @param fields [Array] a list of fields in the form of symbols
-    # @return [Array] the same array of fields
+    # @param fields [Array<Symbol>, :all] a list of fields or <tt>:all</tt> to include all fields
+    # @param options [Hash] optional configuration when using <tt>:all</tt>, ignored otherwise
+    # @option options [Array<Symbol>] :except ([]) a list of fields to exclude
+    # @option options [Boolean] :timestamps (false) include <tt>created_at</tt> and <tt>updated_at</tt> fields
+    # @option options [Boolean] :foreign_keys (false) include fields used to associate models
+    # @option options [Boolean] :associations (true) include nested objects
+    # @return [Array<Symbol>] the list of fields included in the FastAPI response
     def fastapi_standard_interface(fields, options = {})
       if fields == :all
         @fastapi_fields = attributes(options)
@@ -18,10 +23,14 @@ module FastAPIExtension
       end
     end
 
-    # Used to set the standard interface for the second level of a fastapi response (nested)
+    # Set the standard interface for the second level of a FastAPI response (nested).
     #
-    # @param fields [Array] a list of fields in the form of symbols
-    # @return [Array] the same array of fields
+    # @param fields [Array<Symbol>, :all] a list of fields or <tt>:all</tt> to include all fields
+    # @param options [Hash] optional configuration when using <tt>:all</tt>, ignored otherwise
+    # @option options [Array<Symbol>] :except ([]) a list of fields to exclude
+    # @option options [Boolean] :timestamps (false) include <tt>created_at</tt> and <tt>updated_at</tt> fields
+    # @option options [Boolean] :foreign_keys (false) include fields used to associate models
+    # @return [Array<Symbol>] the list of fields included in the FastAPI response
     def fastapi_standard_interface_nested(fields, options = {})
       if fields == :all
         @fastapi_fields_sub = attributes(options.merge({ associations: false }))
@@ -30,15 +39,15 @@ module FastAPIExtension
       end
     end
 
-    # Set safe fields for FastAPIInstance.safe_filter
+    # Set safe fields for FastAPIInstance.safe_filter.
     #
-    # @param fields [Array] a list of fields in the form of symbols
-    # @return [Array] the same array of fields
+    # @param fields [Array<Symbol>] a list of fields
+    # @return [Array<Symbol>] the same array of fields
     def fastapi_safe_fields(fields)
       @fastapi_fields_whitelist = fields
     end
 
-    # Used to set any default filters for the top level fastapi response
+    # Set any default filters for the top level FastAPI response.
     #
     # @param filters [Hash] a hash containing the intended filters
     # @return [Hash] the same filters hash
@@ -46,7 +55,7 @@ module FastAPIExtension
       @fastapi_filters = filters
     end
 
-    # Define custom ORDER BY strings for specific keys
+    # Define custom ORDER BY strings for specific keys.
     #
     # @param keys [Hash] a hash containing the keys: strings for order filters
     # @return [Hash] the same keys hash


### PR DESCRIPTION
##### The symbol `:all` can be used to include 'all' the attributes of a model without enumerating each one.

* `fastapi_standard_interface` and `fastapi_standard_interface_nested` now accept `:all` to represent all attributes of a model.
* A list of options can be specified to further manipulate the attributes included.
  * `except` allows exclusion of a set of attributes.
  * `timestamps` can be set to true if `created_at`/`updated_at` should be included in the response.
  * `foreign_keys` can be set to true if the attributes used to associate models together should be included in the response.
  * `associations` can be set to false if no associated models should be nested in the response.
  * The default options are:
    * `except: []`
    * `timestamps: false`
    * `foreign_keys: false`
    * `associations: true`

For example:
```ruby
# == Schema Information
#
# Table name: buckets
#
#  id         :integer          not null, primary key
#  color      :string
#  material   :string
#  person_id  :integer
#  created_at :datetime         not null
#  updated_at :datetime         not null
#
class Bucket < ActiveRecord::Base                                                                                                                               belongs_to :person                                                                                                                                            has_many :marbles
  # includes color, marbles, and person
  fastapi_standard_interface :all, except :material
end
```

The documentation and source code comments have been updated to include the new functionality.