### PR TITLE
Prepare for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: ruby
+rvm:
+    - 2.2.1
+    - 2.1.5
+    - 2.1.4
+    - 1.9.3
+
+addons:
+  postgresql: "9.3"
+
+before_script:
+  - cp spec/db/database.yml.travis spec/db/database.yml

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,7 @@
 require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new
+
+task default: :spec
+task test: :spec

--- a/fastapi.gemspec
+++ b/fastapi.gemspec
@@ -2,7 +2,6 @@ Gem::Specification.new do |s|
 
   s.name          = 'fastapi'
   s.version       = '0.1.24'
-  s.date          = '2015-03-19'
   s.summary       = 'Easily create robust, standardized API endpoints using lightning-fast database queries'
   s.description   = 'Easily create robust, standardized API endpoints using lightning-fast database queries'
   s.authors       = ['Keith Horwood']

--- a/spec/db/database.yml.travis
+++ b/spec/db/database.yml.travis
@@ -1,0 +1,4 @@
+test:
+  adapter: postgresql
+  database: travis_ci_test
+  username: postgres


### PR DESCRIPTION
* Removing date from `gemspec`, it is automatically set during gem packaging.
* Adding rspec to the `Rakefile`.
  * Tests run as the default rake task.
* Adding `database.yml.travis` and `.travis.yml`.
  * These are used to set up Ruby and Postgres during continuous integration.