### PR TITLE
Not So Small Refactoring

### DIFF
--- a/fastapi.gemspec
+++ b/fastapi.gemspec
@@ -1,11 +1,11 @@
 Gem::Specification.new do |s|
 
   s.name          = 'fastapi'
-  s.version       = '0.1.25'
+  s.version       = '0.1.26'
   s.summary       = 'Easily create robust, standardized API endpoints using lightning-fast database queries'
   s.description   = 'Easily create robust, standardized API endpoints using lightning-fast database queries'
   s.authors       = ['Keith Horwood', 'Trevor Strieber']
-  s.email         = 'keithwhor@gmail.com'
+  s.email         = ['keithwhor@gmail.com', 'trevor@strieber.org']
   s.files         = ['lib/fastapi.rb', 'lib/fastapi/active_record_extension.rb']
   s.homepage      = 'https://github.com/thestorefront/FastAPI'
   s.license       = 'MIT'

--- a/lib/fastapi.rb
+++ b/lib/fastapi.rb
@@ -1,5 +1,5 @@
 require 'oj'
-require 'fastapi/active_record_extension.rb'
+require 'fastapi/active_record_extension'
 
 class FastAPI
 
@@ -672,9 +672,9 @@ class FastAPI
             end
 
             if comparator == 'is'
-              filter_array << data.to_s.upcase + ' = ' + field_string
+              filter_array << "#{data.to_s.upcase} = #{field_string}"
             elsif comparator == 'not'
-              filter_array << 'NOT ' + data.to_s.upcase + ' = ' + field_string
+              filter_array << "NOT #{data.to_s.upcase} = #{field_string}"
             end
 
           elsif data == nil && comparator != 'is_null' && comparator != 'not_null'

--- a/lib/fastapi.rb
+++ b/lib/fastapi.rb
@@ -711,7 +711,8 @@ class FastAPI
         end
       end
 
-      { main: filter_array,
+      {
+        main: filter_array,
         main_order: order,
         has_many: filter_has_many,
         has_many_order: order_has_many,

--- a/lib/fastapi.rb
+++ b/lib/fastapi.rb
@@ -525,9 +525,9 @@ class FastAPI
           elsif data == nil && comparator != 'is_null' && comparator != 'not_null'
 
             if comparator == 'is'
-              filter_array << "NULL = #{field_string}"
+              filter_array << "#{field_string} IS NULL"
             elsif comparator == 'not'
-              filter_array << "NOT NULL = #{field_string}"
+              filter_array << "#{field_string} IS NOT NULL"
             end
 
           elsif data.is_a?(Range) && comparator == 'is'

--- a/lib/fastapi.rb
+++ b/lib/fastapi.rb
@@ -338,11 +338,11 @@ class FastAPI
 
     elsif comparator == 'is_null'
 
-      'NULL = ' + field_string
+      "#{field_string} IS NULL"
 
     elsif comparator == 'not_null'
 
-      'NOT NULL = ' + field_string
+      "#{field_string} IS NOT NULL"
     end
   end
 
@@ -470,7 +470,6 @@ class FastAPI
     if filters.size > 0
 
       filters.each do |key, data|
-
         field = key.to_s
 
         if field.rindex('__').nil?
@@ -523,7 +522,6 @@ class FastAPI
             end
 
           elsif data == nil && comparator != 'is_null' && comparator != 'not_null'
-
             if comparator == 'is'
               filter_array << "#{field_string} IS NULL"
             elsif comparator == 'not'

--- a/lib/fastapi.rb
+++ b/lib/fastapi.rb
@@ -262,9 +262,10 @@ class FastAPI
   # the two following methods are very similar, can reuse
 
   def parse_postgres_array(str)
+    values = []
 
     unless i = str.is_a?(String) && str.index('{')
-      return []
+      values
     end
 
     i += 1

--- a/lib/fastapi.rb
+++ b/lib/fastapi.rb
@@ -309,7 +309,8 @@ class FastAPI
         type_convert = {
           boolean: '::boolean',
           integer: '::integer',
-          float: '::float'
+          float: '::float',
+          string: '::varchar'
         }[type]
 
         type_convert = '::text' if type.nil?

--- a/lib/fastapi.rb
+++ b/lib/fastapi.rb
@@ -259,7 +259,7 @@ class FastAPI
   end
 
   def parse_many(str, fields, types)
-    JSON.parse(str).map do |row|
+    Oj.load(str).map do |row|
       row.values.each_with_object({}).with_index do |(value, values), index|
         values[fields[index]] = api_convert_type(value, types[index])
       end
@@ -349,7 +349,7 @@ class FastAPI
 
   def api_convert_type(val, type, is_array = false)
     if val && is_array
-      JSON.parse(val).map { |inner_value| api_convert_value(inner_value, type) }
+      Oj.load(val).map { |inner_value| api_convert_value(inner_value, type) }
     else
       api_convert_value(val, type)
     end

--- a/lib/fastapi/active_record_extension.rb
+++ b/lib/fastapi/active_record_extension.rb
@@ -48,31 +48,29 @@ module FastAPIExtension
     end
 
     def fastapi_custom_order
-      @fastapi_custom_order or {}
+      @fastapi_custom_order || {}
     end
 
     def fastapi_fields
-      @fastapi_fields or [:id]
+      @fastapi_fields || [:id]
     end
 
     def fastapi_fields_sub
-      @fastapi_fields_sub or [:id]
+      @fastapi_fields_sub || [:id]
     end
 
     def fastapi_filters_whitelist
-      @fastapi_filters_whitelist or @fastapi_fields or [:id]
+      @fastapi_filters_whitelist || @fastapi_fields || [:id]
     end
 
     def fastapi_filters
-      @fastapi_filters or {}
+      @fastapi_filters || {}
     end
 
     def fastapi
       FastAPI.new(self)
     end
-
   end
-
 end
 
 ActiveRecord::Base.send(:include, FastAPIExtension)

--- a/spec/beverage_spec.rb
+++ b/spec/beverage_spec.rb
@@ -1,0 +1,16 @@
+describe Beverage do
+  it_behaves_like 'fastapi_model'
+
+  describe 'when locating a specific beverage' do
+    let!(:beverage) { create(:water) }
+    let(:response)  { ModelHelper.response(Beverage, name: 'water') }
+
+    it_behaves_like 'fastapi_meta' do
+      let(:expected) { { total: 1, count: 1, offset: 0, error: false } }
+    end
+
+    it_behaves_like 'fastapi_data' do
+      let(:expected) { { attributes: %w(id name flavors dish) } }
+    end
+  end
+end

--- a/spec/beverage_spec.rb
+++ b/spec/beverage_spec.rb
@@ -16,7 +16,7 @@ describe Beverage do
 
   describe 'when locating beverages with out a dish' do
     let!(:beverage) { create(:coke) }
-    let(:response) { ModelHelper.response(Beverage, dish_id: nil) }
+    let(:response)  { ModelHelper.response(Beverage, dish_id: nil) }
 
     it_behaves_like 'fastapi_meta' do
       let(:expected) { { total: 1, count: 1, offset: 0, error: false } }
@@ -24,6 +24,110 @@ describe Beverage do
 
     it_behaves_like 'fastapi_data' do
       let(:expected) { { attributes: %w(id name flavors dish) } }
+    end
+  end
+
+  describe 'when locating a beverage using not' do
+    let!(:water)   { create(:water) }
+    let!(:coke)    { create(:coke) }
+    let(:response) { ModelHelper.response(Beverage, name__not: 'water') }
+
+    it_behaves_like 'fastapi_meta' do
+      let(:expected) { { total: 1, count: 1, offset: 0, error: false } }
+    end
+
+    it_behaves_like 'fastapi_data' do
+      let(:expected) { { attributes: %w(id name flavors dish) } }
+    end
+
+    it 'has the correct name' do
+      expect(response['data'].first['name']).to eq 'Coca-Cola'
+    end
+  end
+
+  describe 'when locating a beverage using string contains' do
+    let!(:water)   { create(:water) }
+    let!(:coke)    { create(:coke) }
+    let(:response) { ModelHelper.response(Beverage, name__contains: 'wat') }
+
+    it_behaves_like 'fastapi_meta' do
+      let(:expected) { { total: 1, count: 1, offset: 0, error: false } }
+    end
+
+    it_behaves_like 'fastapi_data' do
+      let(:expected) { { attributes: %w(id name flavors dish) } }
+    end
+
+    it 'has the correct name' do
+      expect(response['data'].first['name']).to eq 'water'
+    end
+  end
+
+  describe 'when locating a beverage using case insensitive string contains' do
+    let!(:water)   { create(:water) }
+    let!(:coke)    { create(:coke) }
+    let(:response) { ModelHelper.response(Beverage, name__icontains: 'CoCa') }
+
+    it_behaves_like 'fastapi_meta' do
+      let(:expected) { { total: 1, count: 1, offset: 0, error: false } }
+    end
+
+    it_behaves_like 'fastapi_data' do
+      let(:expected) { { attributes: %w(id name flavors dish) } }
+    end
+
+    it 'has the correct name' do
+      expect(response['data'].first['name']).to eq 'Coca-Cola'
+    end
+  end
+
+  describe 'when locating a beverage using not null' do
+    let!(:null_drink) { create(:beverage, name: nil) }
+    let!(:beer)       { create(:beer) }
+    let(:response)    { ModelHelper.response(Beverage, name__not_null: nil) }
+
+    it_behaves_like 'fastapi_meta' do
+      let(:expected) { { total: 1, count: 1, offset: 0, error: false } }
+    end
+
+    it_behaves_like 'fastapi_data' do
+      let(:expected) { { attributes: %w(id name flavors dish) } }
+    end
+
+    it 'has the correct name' do
+      expect(response['data'].first['name']).to eq 'Hell Or High Watermelon'
+    end
+  end
+
+  describe 'when locating a beverage by using in an array' do
+    let!(:water)   { create(:water) }
+    let!(:coke)    { create(:coke) }
+    let(:response) { ModelHelper.response(Beverage, name__in: ['water', 'Coca-Cola']) }
+
+    it_behaves_like 'fastapi_meta' do
+      let(:expected) { { total: 2, count: 2, offset: 0, error: false } }
+    end
+
+    it_behaves_like 'fastapi_data' do
+      let(:expected) { { attributes: %w(id name flavors dish) } }
+    end
+  end
+
+  describe 'when locating a beverage using not in' do
+    let!(:water)   { create(:water) }
+    let!(:coke)    { create(:coke) }
+    let(:response) { ModelHelper.response(Beverage, flavors__not_in: 'lime') }
+
+    it_behaves_like 'fastapi_meta' do
+      let(:expected) { { total: 1, count: 1, offset: 0, error: false } }
+    end
+
+    it_behaves_like 'fastapi_data' do
+      let(:expected) { { attributes: %w(id name flavors dish) } }
+    end
+
+    it 'has the correct name' do
+      expect(response['data'].first['name']).to eq 'water'
     end
   end
 end

--- a/spec/beverage_spec.rb
+++ b/spec/beverage_spec.rb
@@ -13,4 +13,17 @@ describe Beverage do
       let(:expected) { { attributes: %w(id name flavors dish) } }
     end
   end
+
+  describe 'when locating beverages with out a dish' do
+    let!(:beverage) { create(:coke) }
+    let(:response) { ModelHelper.response(Beverage, dish_id: nil) }
+
+    it_behaves_like 'fastapi_meta' do
+      let(:expected) { { total: 1, count: 1, offset: 0, error: false } }
+    end
+
+    it_behaves_like 'fastapi_data' do
+      let(:expected) { { attributes: %w(id name flavors dish) } }
+    end
+  end
 end

--- a/spec/bucket_spec.rb
+++ b/spec/bucket_spec.rb
@@ -188,6 +188,24 @@ describe Bucket do
     end
   end
 
+  describe 'when locating buckets with quotes and spaces in the color associated with a person' do
+    let!(:person)      { create(:person_with_buckets_with_quotes_and_spaces) }
+    let(:response)     { ModelHelper.response(Person) }
+    let(:buckets)    { response['data'].first['buckets'] }
+
+    it_behaves_like 'fastapi_meta' do
+      let(:expected) { { total: 1, count: 1, offset: 0, error: false } }
+    end
+
+    it_behaves_like 'fastapi_data' do
+      let(:expected) { { data: buckets.first, attributes: %w(id color material used) } }
+    end
+
+    it 'it should parse colors correctly' do
+      expect(buckets.map { |b| b['color'] }.sort).to eq ['"abc def"', '" abcdef"', '"abcdef "'].sort
+    end
+  end
+
   describe 'when spoofing a bucket with no meta' do
     let(:bucket)   { Bucket.fastapi.spoof([{id: 1, color: 'blue' }]) }
     let(:response) { JSON.parse(bucket) }

--- a/spec/bucket_spec.rb
+++ b/spec/bucket_spec.rb
@@ -10,7 +10,7 @@ describe Bucket do
     end
 
     it_behaves_like 'fastapi_data' do
-      let(:expected) { { attributes: %w(id color material person marbles) } }
+      let(:expected) { { attributes: %w(id color material person marbles used) } }
     end
   end
 
@@ -23,7 +23,7 @@ describe Bucket do
     end
 
     it_behaves_like 'fastapi_data' do
-      let(:expected) { { attributes: %w(id color material person marbles) } }
+      let(:expected) { { attributes: %w(id color material person marbles used) } }
     end
   end
 
@@ -50,7 +50,7 @@ describe Bucket do
     end
 
     it_behaves_like 'fastapi_data' do
-      let(:expected) { { attributes: %w(id color material person marbles) } }
+      let(:expected) { { attributes: %w(id color material person marbles used) } }
     end
   end
 
@@ -63,7 +63,7 @@ describe Bucket do
     end
 
     it_behaves_like 'fastapi_data' do
-      let(:expected) { { attributes: %w(id color material person marbles created_at) } }
+      let(:expected) { { attributes: %w(id color material person marbles used created_at) } }
     end
   end
 
@@ -77,7 +77,7 @@ describe Bucket do
     end
 
     it_behaves_like 'fastapi_data' do
-      let(:expected) { { attributes: %w(id color material person marbles) } }
+      let(:expected) { { attributes: %w(id color material person marbles used) } }
     end
 
     it 'returns only marbles that match the default filter' do
@@ -96,7 +96,7 @@ describe Bucket do
     end
 
     it_behaves_like 'fastapi_data' do
-      let(:expected) { { attributes: %w(id color material person marbles) } }
+      let(:expected) { { attributes: %w(id color material person marbles used) } }
     end
 
     it 'has the correct id' do

--- a/spec/bucket_spec.rb
+++ b/spec/bucket_spec.rb
@@ -86,6 +86,42 @@ describe Bucket do
     end
   end
 
+  describe 'when locating a bucket using a boolean' do
+    let!(:bucket)      { create(:bucket) }
+    let!(:used_bucket) { create(:used_bucket) }
+    let(:response) { ModelHelper.response(Bucket, used: true) }
+
+    it_behaves_like 'fastapi_meta' do
+      let(:expected) { { total: 1, count: 1, offset: 0, error: false } }
+    end
+
+    it_behaves_like 'fastapi_data' do
+      let(:expected) { { attributes: %w(id color material person marbles used) } }
+    end
+
+    it 'returns a used bucket' do
+      expect(response['data'].first['used']).to eq true
+    end
+  end
+
+  describe 'when locating a bucket using a boolean string' do
+    let!(:bucket)      { create(:bucket) }
+    let!(:used_bucket) { create(:used_bucket) }
+    let(:response) { ModelHelper.response(Bucket, used: 't') }
+
+    it_behaves_like 'fastapi_meta' do
+      let(:expected) { { total: 1, count: 1, offset: 0, error: false } }
+    end
+
+    it_behaves_like 'fastapi_data' do
+      let(:expected) { { attributes: %w(id color material person marbles used) } }
+    end
+
+    it 'returns a used bucket' do
+      expect(response['data'].first['used']).to eq true
+    end
+  end
+
   describe 'when locating a bucket by id' do
     let!(:bucket)        { create(:bucket) }
     let(:response)       { ModelHelper.fetch(Bucket, bucket.id) }
@@ -126,7 +162,7 @@ describe Bucket do
 
     it_behaves_like 'fastapi_data' do
       let(:expected) { { data: response['data'].first['buckets'].first,
-                         attributes: %w(id color material) } }
+                         attributes: %w(id color material used) } }
     end
   end
 
@@ -140,7 +176,7 @@ describe Bucket do
     end
 
     it_behaves_like 'fastapi_data' do
-      let(:expected) { { data: incomplete_bucket, attributes: %w(id color material) } }
+      let(:expected) { { data: incomplete_bucket, attributes: %w(id color material used) } }
     end
 
     it 'has a nil color' do

--- a/spec/bucket_spec.rb
+++ b/spec/bucket_spec.rb
@@ -14,6 +14,32 @@ describe Bucket do
     end
   end
 
+  describe 'when locating a specific bucket using safe filters' do
+    let!(:bucket)  { create(:blue_paper_bucket) }
+    let(:response) { ModelHelper.response(Bucket, { color: 'blue', material: 'paper' }, { safe: true }) }
+
+    it_behaves_like 'fastapi_meta' do
+      let(:expected) { { total: 1, count: 1, offset: 0, error: false } }
+    end
+
+    it_behaves_like 'fastapi_data' do
+      let(:expected) { { attributes: %w(id color material person marbles) } }
+    end
+  end
+
+  describe 'when locating a specific bucket using safe filters that are not allowed' do
+    let!(:bucket)  { create(:blue_paper_bucket) }
+    let(:response) { ModelHelper.response(Bucket, { id: 1 }, { safe: true }) }
+
+    it_behaves_like 'fastapi_meta' do
+      let(:expected) { { total: 0, count: 0, offset: 0, error: /Filter "id" not supported/ } }
+    end
+
+    it 'has an empty data array' do
+      expect(response['data']).to eq []
+    end
+  end
+
   describe 'when filtering through many buckets' do
     let!(:red_buckets)  { create_list(:red_plastic_bucket, 15) }
     let!(:blue_buckets) { create_list(:blue_paper_bucket, 15) }
@@ -29,8 +55,8 @@ describe Bucket do
   end
 
   describe 'when whitelisting bucket attributes' do
-    let!(:bucket) { create(:bucket) }
-    let(:response) { ModelHelper.whitelisted_response(Bucket, 'created_at') }
+    let!(:bucket)  { create(:bucket) }
+    let(:response) { ModelHelper.response(Bucket, {}, whitelist: 'created_at') }
 
     it_behaves_like 'fastapi_meta' do
       let(:expected) { { total: 1, count: 1, offset: 0, error: false } }

--- a/spec/bucket_spec.rb
+++ b/spec/bucket_spec.rb
@@ -89,7 +89,7 @@ describe Bucket do
   describe 'when locating a bucket using a boolean' do
     let!(:bucket)      { create(:bucket) }
     let!(:used_bucket) { create(:used_bucket) }
-    let(:response) { ModelHelper.response(Bucket, used: true) }
+    let(:response)     { ModelHelper.response(Bucket, used: true) }
 
     it_behaves_like 'fastapi_meta' do
       let(:expected) { { total: 1, count: 1, offset: 0, error: false } }
@@ -107,7 +107,7 @@ describe Bucket do
   describe 'when locating a bucket using a boolean string' do
     let!(:bucket)      { create(:bucket) }
     let!(:used_bucket) { create(:used_bucket) }
-    let(:response) { ModelHelper.response(Bucket, used: 't') }
+    let(:response)     { ModelHelper.response(Bucket, used: 't') }
 
     it_behaves_like 'fastapi_meta' do
       let(:expected) { { total: 1, count: 1, offset: 0, error: false } }
@@ -189,9 +189,9 @@ describe Bucket do
   end
 
   describe 'when locating buckets with quotes and spaces in the color associated with a person' do
-    let!(:person)      { create(:person_with_buckets_with_quotes_and_spaces) }
-    let(:response)     { ModelHelper.response(Person) }
-    let(:buckets)    { response['data'].first['buckets'] }
+    let!(:person)  { create(:person_with_buckets_with_quotes_and_spaces) }
+    let(:response) { ModelHelper.response(Person) }
+    let(:buckets)  { response['data'].first['buckets'] }
 
     it_behaves_like 'fastapi_meta' do
       let(:expected) { { total: 1, count: 1, offset: 0, error: false } }

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -3,6 +3,7 @@ ActiveRecord::Schema.define(version: 20150330000000) do
     t.string   'color'
     t.string   'material'
     t.integer  'person_id'
+    t.boolean  'used'
 
     t.timestamps null: false
   end

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -31,9 +31,21 @@ ActiveRecord::Schema.define(version: 20150330000000) do
   create_table 'dishes', force: true do |t|
     t.string   'name'
     t.string   'ingredients', array: true, default: []
+    t.integer  'person_id'
 
     t.timestamps null: false
   end
 
   add_index 'dishes', ['ingredients'], name: 'index_dishes_on_ingredients', using: :btree
+  add_index 'dishes', ['person_id'], name: 'index_dishes_on_person_id', using: :btree
+
+  create_table 'beverages', force: true do |t|
+    t.string   'name'
+    t.string   'flavors', array: true, default: []
+    t.integer  'dish_id'
+
+    t.timestamps null: false
+  end
+
+  add_index 'beverages', ['dish_id'], name: 'index_beverages_on_dish_id', using: :btree
 end

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -27,4 +27,13 @@ ActiveRecord::Schema.define(version: 20150330000000) do
 
     t.timestamps null: false
   end
+
+  create_table 'dishes', force: true do |t|
+    t.string   'name'
+    t.string   'ingredients', array: true, default: []
+
+    t.timestamps null: false
+  end
+
+  add_index 'dishes', ['ingredients'], name: 'index_dishes_on_ingredients', using: :btree
 end

--- a/spec/dish_spec.rb
+++ b/spec/dish_spec.rb
@@ -33,7 +33,7 @@ describe Dish do
   end
 
   describe 'when locating a beverage associated with a dish' do
-    let!(:dish) { create(:burrito_with_coke) }
+    let!(:dish)    { create(:burrito_with_coke) }
     let(:response) { ModelHelper.response(Dish, name: 'burrito') }
     let(:beverage) { response['data'].first['beverage'] }
 

--- a/spec/dish_spec.rb
+++ b/spec/dish_spec.rb
@@ -3,14 +3,14 @@ describe Dish do
 
   describe 'when locating a specific dish' do
     let!(:dish)    { create(:burrito) }
-    let(:response) { ModelHelper.response(Dish, name: 'burrito' ) }
+    let(:response) { ModelHelper.response(Dish, name: 'burrito') }
 
     it_behaves_like 'fastapi_meta' do
       let(:expected) { { total: 1, count: 1, offset: 0, error: false } }
     end
 
     it_behaves_like 'fastapi_data' do
-      let(:expected) { { attributes: %w(id name ingredients) } }
+      let(:expected) { { attributes: %w(id name ingredients person beverage) } }
     end
   end
 
@@ -24,11 +24,29 @@ describe Dish do
     end
 
     it_behaves_like 'fastapi_data' do
-      let(:expected) { { attributes: %w(id name ingredients) } }
+      let(:expected) { { attributes: %w(id name ingredients person beverage) } }
     end
 
     it 'contains pickles' do
       expect(response['data'].first['ingredients']).to include('pickle')
+    end
+  end
+
+  describe 'when locating a beverage associated with a dish' do
+    let!(:dish) { create(:burrito_with_coke) }
+    let(:response) { ModelHelper.response(Dish, name: 'burrito') }
+    let(:beverage) { response['data'].first['beverage'] }
+
+    it_behaves_like 'fastapi_meta' do
+      let(:expected) { { total: 1, count: 1, offset: 0, error: false } }
+    end
+
+    it_behaves_like 'fastapi_data' do
+      let(:expected) { { data: beverage, attributes: %w(id name flavors) } }
+    end
+
+    it 'has the right flavors' do
+      expect(beverage['flavors'].sort).to eq %w(sweet vanilla cinnamon orange lime lemon nutmeg).sort
     end
   end
 end

--- a/spec/dish_spec.rb
+++ b/spec/dish_spec.rb
@@ -1,0 +1,34 @@
+describe Dish do
+  it_behaves_like 'fastapi_model'
+
+  describe 'when locating a specific dish' do
+    let!(:dish)    { create(:burrito) }
+    let(:response) { ModelHelper.response(Dish, name: 'burrito' ) }
+
+    it_behaves_like 'fastapi_meta' do
+      let(:expected) { { total: 1, count: 1, offset: 0, error: false } }
+    end
+
+    it_behaves_like 'fastapi_data' do
+      let(:expected) { { attributes: %w(id name ingredients) } }
+    end
+  end
+
+  describe 'when locating a dish by ingredient' do
+    let!(:cheeseburger)    { create(:cheeseburger) }
+    let!(:margarita_pizza) { create(:margarita_pizza) }
+    let(:response)         { ModelHelper.response(Dish, ingredients: 'pickle') }
+
+    it_behaves_like 'fastapi_meta' do
+      let(:expected) { { total: 1, count: 1, offset: 0, error: false } }
+    end
+
+    it_behaves_like 'fastapi_data' do
+      let(:expected) { { attributes: %w(id name ingredients) } }
+    end
+
+    it 'contains pickles' do
+      expect(response['data'].first['ingredients']).to include('pickle')
+    end
+  end
+end

--- a/spec/factories/beverage.rb
+++ b/spec/factories/beverage.rb
@@ -1,0 +1,20 @@
+FactoryGirl.define do
+  factory :beverage do
+    sequence(:name) { |n| "Example Beverage #{n}" }
+
+    factory :water do
+      name 'water'
+      flavors ['water']
+    end
+
+    factory :coke do
+      name 'Coca-Cola'
+      flavors ['sweet', 'vanilla', 'cinnamon', 'orange', 'lime', 'lemon', 'nutmeg']
+    end
+
+    factory :beer do
+      name 'Hell Or High Watermelon'
+      flavors ['sweet', 'watermelon', 'wheat', 'yeast']
+    end
+  end
+end

--- a/spec/factories/bucket.rb
+++ b/spec/factories/bucket.rb
@@ -2,6 +2,11 @@ FactoryGirl.define do
   factory :bucket do
     color    { %w(red green blue black white orange).sample }
     material { %w(wood plastic paper concrete).sample }
+    used     false
+
+    factory :used_bucket do
+      used true
+    end
 
     factory :red_plastic_bucket do
       color    'red'

--- a/spec/factories/dish.rb
+++ b/spec/factories/dish.rb
@@ -1,0 +1,20 @@
+FactoryGirl.define do
+  factory :dish do
+    sequence(:name) { |n| "Example Dish #{n}" }
+
+    factory :margarita_pizza do
+      name 'margarita pizza'
+      ingredients ['dough', 'marinara', 'mozarella', 'basil']
+    end
+
+    factory :cheeseburger do
+      name 'cheeseburger'
+      ingredients ['wheat bun', 'ground beef', 'american cheese', 'pickle', 'lettuce', 'onion', 'ketchup']
+    end
+
+    factory :burrito do
+      name 'burrito'
+      ingredients ['flour tortilla', 'shredded chicken', 'queso fresco', 'black beans', 'avocado']
+    end
+  end
+end

--- a/spec/factories/dish.rb
+++ b/spec/factories/dish.rb
@@ -10,11 +10,19 @@ FactoryGirl.define do
     factory :cheeseburger do
       name 'cheeseburger'
       ingredients ['wheat bun', 'ground beef', 'american cheese', 'pickle', 'lettuce', 'onion', 'ketchup']
+
+      factory :cheeseburger_with_beer do
+        association :beverage, factory: :beer
+      end
     end
 
     factory :burrito do
       name 'burrito'
       ingredients ['flour tortilla', 'shredded chicken', 'queso fresco', 'black beans', 'avocado']
+
+      factory :burrito_with_coke do
+        association :beverage, factory: :coke
+      end
     end
   end
 end

--- a/spec/factories/person.rb
+++ b/spec/factories/person.rb
@@ -32,5 +32,22 @@ FactoryGirl.define do
                     color: nil, material: 'plastic')
       end
     end
+
+    factory :person_with_buckets_with_quotes_and_spaces do
+      name 'Person with Buckets with quotes and spaces'
+
+      transient do
+        bucket_count 1
+      end
+
+      after(:create) do |person, evaluator|
+        create_list(:bucket, evaluator.bucket_count, person: person,
+                   color: '"abc def"', material: 'paper')
+        create_list(:bucket, evaluator.bucket_count, person: person,
+                   color: '" abcdef"', material: 'paper')
+        create_list(:bucket, evaluator.bucket_count, person: person,
+                   color: '"abcdef "', material: 'paper')
+      end
+    end
   end
 end

--- a/spec/factories/person.rb
+++ b/spec/factories/person.rb
@@ -49,5 +49,14 @@ FactoryGirl.define do
                    color: '"abcdef "', material: 'paper')
       end
     end
+
+    factory :person_with_dishes do
+      name 'Person with Dishes'
+
+      after(:create) do |person|
+        create_list(:burrito, 1, person: person)
+        create_list(:cheeseburger, 1, person: person)
+      end
+    end
   end
 end

--- a/spec/helpers/model_helper.rb
+++ b/spec/helpers/model_helper.rb
@@ -1,11 +1,13 @@
 module ModelHelper
-  def self.response(clazz, filter = {})
-    results = clazz.fastapi.filter(filter)
-    JSON.parse(results.response)
-  end
+  def self.response(clazz, filter = {}, options = {})
+    api = clazz.fastapi
 
-  def self.whitelisted_response(clazz, whitelist, filter = {})
-    results = clazz.fastapi.whitelist([*whitelist]).filter(filter)
+    if options.key?(:whitelist)
+      api.whitelist([*options[:whitelist]])
+    end
+
+    results = options[:safe] ? api.safe_filter(filter) : api.filter(filter)
+
     JSON.parse(results.response)
   end
 

--- a/spec/helpers/model_helper.rb
+++ b/spec/helpers/model_helper.rb
@@ -8,11 +8,11 @@ module ModelHelper
 
     results = options[:safe] ? api.safe_filter(filter) : api.filter(filter)
 
-    JSON.parse(results.response)
+    Oj.load(results.response)
   end
 
   def self.fetch(clazz, id)
     results = clazz.fastapi.fetch(id)
-    JSON.parse(results.response)
+    Oj.load(results.response)
   end
 end

--- a/spec/marble_spec.rb
+++ b/spec/marble_spec.rb
@@ -158,4 +158,23 @@ describe Marble do
       expect(ids).to eq ids.sort
     end
   end
+
+  describe 'when locating marbles without an order' do
+    let!(:buckets) { create(:bucket_with_marbles) }
+    let(:response) { ModelHelper.response(Marble, { __order: 'id' }) }
+    let(:marbles)  { response['data'] }
+
+    it_behaves_like 'fastapi_meta' do
+      let(:expected) { { total: 10, count: 10, offset: 0, error: false } }
+    end
+
+    it_behaves_like 'fastapi_data' do
+      let(:expected) { { attributes: %w(id color radius bucket) } }
+    end
+
+    it 'is returned in the correct order (ASC)' do
+      ids = marbles.map { |m| m['id'] }
+      expect(ids).to eq ids.sort
+    end
+  end
 end

--- a/spec/marble_spec.rb
+++ b/spec/marble_spec.rb
@@ -177,4 +177,44 @@ describe Marble do
       expect(ids).to eq ids.sort
     end
   end
+
+  describe 'when locating marbles using offset' do
+    let!(:buckets)    { create(:bucket_with_marbles) }
+    let(:response)    { ModelHelper.response(Marble, { __offset: 5, __order: [:id, :ASC] }) }
+    let(:marbles)     { response['data'] }
+    let(:correct_ids) { Marble.pluck(:id).sort.drop(5) }
+
+    it_behaves_like 'fastapi_meta' do
+      let(:expected) { { total: 10, count: 5, offset: 5, error: false } }
+    end
+
+    it_behaves_like 'fastapi_data' do
+      let(:expected) { { attributes: %w(id color radius bucket) } }
+    end
+
+    it 'is returned the correct marbles' do
+      ids = marbles.map { |m| m['id'] }
+      expect(ids).to eq correct_ids
+    end
+  end
+
+  describe 'when locating marbles using count' do
+    let!(:buckets)    { create(:bucket_with_marbles) }
+    let(:response)    { ModelHelper.response(Marble, { __count: 5, __order: [:id, :ASC] }) }
+    let(:marbles)     { response['data'] }
+    let(:correct_ids) { Marble.pluck(:id).sort.first(5) }
+
+    it_behaves_like 'fastapi_meta' do
+      let(:expected) { { total: 10, count: 5, offset: 0, error: false } }
+    end
+
+    it_behaves_like 'fastapi_data' do
+      let(:expected) { { attributes: %w(id color radius bucket) } }
+    end
+
+    it 'is returned the correct marbles' do
+      ids = marbles.map { |m| m['id'] }
+      expect(ids).to eq correct_ids
+    end
+  end
 end

--- a/spec/marble_spec.rb
+++ b/spec/marble_spec.rb
@@ -30,7 +30,7 @@ describe Marble do
 
   describe 'when whitelisting marble attributes' do
     let!(:marble) { create(:marble) }
-    let(:response) { ModelHelper.whitelisted_response(Marble, 'created_at') }
+    let(:response) { ModelHelper.response(Marble, {}, whitelist: 'created_at') }
 
     it_behaves_like 'fastapi_meta' do
       let(:expected) { { total: 1, count: 1, offset: 0, error: false } }

--- a/spec/marble_spec.rb
+++ b/spec/marble_spec.rb
@@ -121,7 +121,7 @@ describe Marble do
     end
   end
 
-  describe 'when locating marbles and specifying an order' do
+  describe 'when locating marbles and specifying an order DESC' do
     let!(:buckets) { create(:bucket_with_marbles) }
     let(:response) { ModelHelper.response(Marble, { __order: [:id, :DESC] }) }
     let(:marbles)  { response['data'] }
@@ -137,6 +137,25 @@ describe Marble do
     it 'is returned in the correct order' do
       ids = marbles.map { |m| m['id'] }
       expect(ids).to eq ids.sort.reverse
+    end
+  end
+
+  describe 'when locating marbles and specifying an order ASC' do
+    let!(:buckets) { create(:bucket_with_marbles) }
+    let(:response) { ModelHelper.response(Marble, { __order: [:id, :ASC] }) }
+    let(:marbles)  { response['data'] }
+
+    it_behaves_like 'fastapi_meta' do
+      let(:expected) { { total: 10, count: 10, offset: 0, error: false } }
+    end
+
+    it_behaves_like 'fastapi_data' do
+      let(:expected) { { attributes: %w(id color radius bucket) } }
+    end
+
+    it 'is returned in the correct order' do
+      ids = marbles.map { |m| m['id'] }
+      expect(ids).to eq ids.sort
     end
   end
 end

--- a/spec/marble_spec.rb
+++ b/spec/marble_spec.rb
@@ -120,4 +120,23 @@ describe Marble do
       expect(incomplete_marble['radius']).to eq 5
     end
   end
+
+  describe 'when locating marbles and specifying an order' do
+    let!(:buckets) { create(:bucket_with_marbles) }
+    let(:response) { ModelHelper.response(Marble, { __order: [:id, :DESC] }) }
+    let(:marbles)  { response['data'] }
+
+    it_behaves_like 'fastapi_meta' do
+      let(:expected) { { total: 10, count: 10, offset: 0, error: false } }
+    end
+
+    it_behaves_like 'fastapi_data' do
+      let(:expected) { { attributes: %w(id color radius bucket) } }
+    end
+
+    it 'is returned in the correct order' do
+      ids = marbles.map { |m| m['id'] }
+      expect(ids).to eq ids.sort.reverse
+    end
+  end
 end

--- a/spec/models/beverage.rb
+++ b/spec/models/beverage.rb
@@ -1,0 +1,6 @@
+class Beverage < ActiveRecord::Base
+  belongs_to :dish
+
+  fastapi_standard_interface [:id, :name, :flavors, :dish]
+  fastapi_standard_interface_nested [:id, :name, :flavors]
+end

--- a/spec/models/bucket.rb
+++ b/spec/models/bucket.rb
@@ -3,8 +3,8 @@ class Bucket < ActiveRecord::Base
   has_many :marbles
 
   fastapi_safe_fields               [:color, :material]
-  fastapi_standard_interface        [:id, :color, :material, :person, :marbles]
-  fastapi_standard_interface_nested [:id, :color, :material]
+  fastapi_standard_interface        [:id, :color, :material, :person, :marbles, :used]
+  fastapi_standard_interface_nested [:id, :color, :material, :used]
 
   fastapi_default_filters(marbles: { radius__lte: 10 })
 end

--- a/spec/models/bucket.rb
+++ b/spec/models/bucket.rb
@@ -2,6 +2,7 @@ class Bucket < ActiveRecord::Base
   belongs_to :person
   has_many :marbles
 
+  fastapi_safe_fields               [:color, :material]
   fastapi_standard_interface        [:id, :color, :material, :person, :marbles]
   fastapi_standard_interface_nested [:id, :color, :material]
 

--- a/spec/models/dish.rb
+++ b/spec/models/dish.rb
@@ -1,4 +1,7 @@
 class Dish < ActiveRecord::Base
+  has_one :beverage
+  belongs_to :person
 
-  fastapi_standard_interface [:id, :name, :ingredients]
+  fastapi_standard_interface [:id, :name, :ingredients, :beverage, :person]
+  fastapi_standard_interface_nested [:id, :name, :ingredients]
 end

--- a/spec/models/dish.rb
+++ b/spec/models/dish.rb
@@ -1,0 +1,4 @@
+class Dish < ActiveRecord::Base
+
+  fastapi_standard_interface [:id, :name, :ingredients]
+end

--- a/spec/models/person.rb
+++ b/spec/models/person.rb
@@ -1,6 +1,7 @@
 class Person < ActiveRecord::Base
   has_many :buckets
+  has_many :dishes
 
-  fastapi_standard_interface        [:id, :name, :gender, :age, :buckets]
+  fastapi_standard_interface        [:id, :name, :gender, :age, :buckets, :dishes]
   fastapi_standard_interface_nested [:id, :name, :gender, :age]
 end

--- a/spec/person_spec.rb
+++ b/spec/person_spec.rb
@@ -29,7 +29,7 @@ describe Person do
 
   describe 'when whitelisting person attributes' do
     let!(:person) { create(:person) }
-    let(:response) { ModelHelper.whitelisted_response(Person, 'created_at') }
+    let(:response) { ModelHelper.response(Person, {}, whitelist: 'created_at') }
 
     it_behaves_like 'fastapi_meta' do
       let(:expected) { { total: 1, count: 1, offset: 0, error: false } }

--- a/spec/person_spec.rb
+++ b/spec/person_spec.rb
@@ -14,7 +14,7 @@ describe Person do
     end
   end
 
-  describe 'when filtering through many people' do
+  describe 'when locating a person using greater than' do
     let!(:people)  { create_list(:person, 15) }
     let(:response) { ModelHelper.response(Person, age__gte: 0) }
 
@@ -24,6 +24,25 @@ describe Person do
 
     it_behaves_like 'fastapi_data' do
       let(:expected) { { attributes: %w(id name gender age buckets dishes) } }
+    end
+  end
+
+  describe 'when locating a person using less than' do
+    let!(:young_person) { create(:person, name: 'Young Dude', age: 15) }
+    let!(:older_person) { create(:person, name: 'Old Guy', age: 65) }
+
+    let(:response) {ModelHelper.response(Person, age__lt: 20) }
+
+    it_behaves_like 'fastapi_meta' do
+      let(:expected) { { total: 1, count: 1, offset: 0, error: false } }
+    end
+
+    it_behaves_like 'fastapi_data' do
+      let(:expected) { { attributes: %w(id name gender age buckets dishes) } }
+    end
+
+    it 'has the correct name' do
+      expect(response['data'].first['name']).to eq 'Young Dude'
     end
   end
 

--- a/spec/person_spec.rb
+++ b/spec/person_spec.rb
@@ -10,7 +10,7 @@ describe Person do
     end
 
     it_behaves_like 'fastapi_data' do
-      let(:expected) { { attributes: %w(id name gender age buckets) } }
+      let(:expected) { { attributes: %w(id name gender age buckets dishes) } }
     end
   end
 
@@ -23,7 +23,7 @@ describe Person do
     end
 
     it_behaves_like 'fastapi_data' do
-      let(:expected) { { attributes: %w(id name gender age buckets) } }
+      let(:expected) { { attributes: %w(id name gender age buckets dishes) } }
     end
   end
 
@@ -36,7 +36,7 @@ describe Person do
     end
 
     it_behaves_like 'fastapi_data' do
-      let(:expected) { { attributes: %w(id name gender age buckets created_at) } }
+      let(:expected) { { attributes: %w(id name gender age buckets dishes created_at) } }
     end
   end
 
@@ -50,7 +50,7 @@ describe Person do
     end
 
     it_behaves_like 'fastapi_data' do
-      let(:expected) { { attributes: %w(id name gender age buckets) } }
+      let(:expected) { { attributes: %w(id name gender age buckets dishes) } }
     end
 
     it 'has the correct id' do

--- a/spec/shared/fastapi_model.rb
+++ b/spec/shared/fastapi_model.rb
@@ -22,4 +22,23 @@ shared_examples 'fastapi_model' do
   it 'responds to fastapi.to_hash' do
     expect(subject.class.fastapi).to respond_to(:to_hash)
   end
+
+  describe 'when calling fastapi.reject' do
+    it 'responds to fastapi.reject' do
+      expect(subject.class.fastapi).to respond_to(:reject)
+    end
+
+    it 'forms the default rejection response' do
+      response = Oj.load(subject.class.fastapi.reject)
+      message  = response['meta']['error']['message']
+      expect(message).to eq 'Access denied'
+    end
+
+    it 'allows specifying the rejection response message' do
+      custom   = "I'm sorry, Dave. I'm afraid I can't do that."
+      response = Oj.load(subject.class.fastapi.reject(custom))
+      message  = response['meta']['error']['message']
+      expect(message).to eq custom
+    end
+  end
 end


### PR DESCRIPTION
## FastAPI 0.1.26

### Adding tests.
* Adding a test to check for correct ordering.
  * Testing default ordering.
  * Testing when `ASC` or `DESC` are specified.
* Adding safe filter testing.
  * Adding bucket safe filtering.
    * Tests for both allowed and not allowed filter criteria.
  * Modifying `ModelHelper.response` to take a whitelist and safe flag.
  * Removing old `ModelHelper.whitelisted_response` method.
* Adding tests that filter by:
  * `boolean`
  * `gt` / `lt`
  * `not`
  * `null` / `not null`
  * `in` / `not in`
  * `contains` / `icontains`.
* Adding tests that cover options:
  * `count`
  * `offset`
* Testing `reject` with and without custom rejection responses.

#### Refactoring
* Changing how filtering by boolean works.
  * The variable `value` was shadowing an outer variable, changed to `data`.
  * Added a comment to `!!data != data`.
  * No longer using hash to determine `f` or `false` -> `false`.
  * `is` and `not` comparator checks need to run every time.
    * Removed `if`.
 * Using string interpolation, not concatenation.
* `require` does not require `.rb`.

#### Fixing support for `has_one` relationships.
* Correcting the generated SQL.
* Adding tests that cover `has_one` functionality.

#### Removing manual parsing of PG arrays.
* Converting them to JSON via SQL.
* Parsing the results using ~~`JSON.parse`~~ `Oj.load`.
* Adding tests to cover value content edge cases (`"` and ` `).

#### Misc. Bug fixes
* Fixing filtering using `null` and `not null`.
* Adding string type conversion when dealing with arrays.

#### Some more refactoring and style changes.
* Using parens around method parameters.
  * https://github.com/bbatsov/ruby-style-guide#no-dsl-parens
* Removing trailing commas in hash literals.
  * https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
* Converted not, or, and -> !, ||, &&.
  * https://github.com/bbatsov/ruby-style-guide#bang-not-not
  * https://github.com/bbatsov/ruby-style-guide#no-and-or-or
* Switching from if ! to unless for unless there is an else block.
  * https://github.com/bbatsov/ruby-style-guide#unless-for-negatives
* Removed parens when calling methods with no parameters.
  * https://github.com/bbatsov/ruby-style-guide#no-args-no-parens
* Using ||= to set possibly initialized variables.
  * https://github.com/bbatsov/ruby-style-guide#double-pipe-for-uninit
* Removing unnecessary return usage.
  * https://github.com/bbatsov/ruby-style-guide#no-explicit-return
* Using string interpolation instead of concatenating.
  * https://github.com/bbatsov/ruby-style-guide#string-interpolation
* Extracted the clamp functionality into a method.
* Extracted the error message functionality into a method.
* Using `||` to set default values.
* Using `Object#try` to handle calling methods on possible nil objects.
* Using `.each_with_object` where possible to avoid creating objects outside of a loop and appending to them.
* Removing commented code.
* Using `exclude?` vs `!include?`.
* Merging two hashes instead of looping through one hash to add in elements from the other.
* Removing overlapping classes from the `gsub` regex:
  * `\w` includes `\d` and `_`.

#### Lining up private and the private methods.
* Sorry about this messy diff!
* The private keyword and its related methods should be indented the same.
* https://github.com/bbatsov/ruby-style-guide#indent-public-private-protected
