### PR TITLE
Allow passing in fields as arguments or as an array to whitelist

### DIFF
--- a/lib/fastapi.rb
+++ b/lib/fastapi.rb
@@ -29,8 +29,8 @@ module FastAPI
     #
     # @param fields [Array] an array containing fields to whitelist for the SQL query. Can also pass in fields as arguments.
     # @return [FastAPI] the current instance
-    def whitelist(fields = [])
-      @whitelist_fields.concat(fields)
+    def whitelist(*fields)
+      @whitelist_fields.concat([fields].flatten)
 
       self
     end

--- a/spec/helpers/model_helper.rb
+++ b/spec/helpers/model_helper.rb
@@ -3,7 +3,7 @@ module ModelHelper
     api = clazz.fastapi
 
     if options.key?(:whitelist)
-      api.whitelist([*options[:whitelist]])
+      api.whitelist(options[:whitelist])
     end
 
     results = options[:safe] ? api.safe_filter(filter) : api.filter(filter)

--- a/spec/person_spec.rb
+++ b/spec/person_spec.rb
@@ -48,14 +48,29 @@ describe Person do
 
   describe 'when whitelisting person attributes' do
     let!(:person) { create(:person) }
-    let(:response) { ModelHelper.response(Person, {}, whitelist: 'created_at') }
 
-    it_behaves_like 'fastapi_meta' do
-      let(:expected) { { total: 1, count: 1, offset: 0, error: false } }
+    describe 'as arguments' do
+      let(:response) { ModelHelper.response(Person, {}, whitelist: 'created_at') }
+
+      it_behaves_like 'fastapi_meta' do
+        let(:expected) { { total: 1, count: 1, offset: 0, error: false } }
+      end
+
+      it_behaves_like 'fastapi_data' do
+        let(:expected) { { attributes: %w(id name gender age buckets dishes created_at) } }
+      end
     end
 
-    it_behaves_like 'fastapi_data' do
-      let(:expected) { { attributes: %w(id name gender age buckets dishes created_at) } }
+    describe 'as an array' do
+      let(:response) { Oj.load(Person.fastapi.whitelist([:created_at]).filter.response) }
+
+      it_behaves_like 'fastapi_meta' do
+        let(:expected) { { total: 1, count: 1, offset: 0, error: false } }
+      end
+
+      it_behaves_like 'fastapi_data' do
+        let(:expected) { { attributes: %w(id name gender age buckets dishes created_at) } }
+      end
     end
   end
 


### PR DESCRIPTION
The documentation states that the whitelist method can take the fields to be whitelisted as either an array of fields or as arguments on the whitelist method. This fixes the whitelist method to support that.