### PR TITLE
Adding enhanced spoofing

### DIFF
--- a/fastapi.gemspec
+++ b/fastapi.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.license       = 'MIT'
 
   s.add_runtime_dependency 'activerecord', '>= 3.2.0'
-  s.add_runtime_dependency 'activesupport', '>= 3.2.0'
+
   s.add_runtime_dependency 'oj', '~> 2.9.9'
   s.add_runtime_dependency 'pg', '>= 0.18.1'
 

--- a/lib/fastapi.rb
+++ b/lib/fastapi.rb
@@ -5,6 +5,7 @@ require 'fastapi/extension'
 require 'fastapi/comparison'
 require 'fastapi/conversions'
 require 'fastapi/sql'
+require 'fastapi/spoof'
 require 'fastapi/utilities'
 
 module FastAPI
@@ -122,11 +123,11 @@ module FastAPI
     #
     # @return [String] JSON data and metadata
     def spoof(data = [], meta = {})
-      meta[:total]  ||= data.count
-      meta[:count]  ||= data.count
-      meta[:offset] ||= 0
+      FastAPI::Spoof.new(data, meta).spoof
+    end
 
-      Oj.dump(meta: meta, data: data)
+    def spoof!(data, meta = {})
+      FastAPI::Spoof.new(data, meta, @whitelist_fields).spoof!
     end
 
     # Returns a JSONified string representing a rejected API response with invalid fields parameters

--- a/lib/fastapi/spoof.rb
+++ b/lib/fastapi/spoof.rb
@@ -1,0 +1,54 @@
+module FastAPI
+  class Spoof
+
+    def initialize(data, meta = {}, whitelist = nil)
+      @data      = data
+      @meta      = default_meta.merge(meta)
+      @whitelist = whitelist
+    end
+
+    def spoof(data = nil)
+      Oj.dump(meta: @meta, data: data || @data)
+    end
+
+    def spoof!
+      spoof(prepared_data)
+    end
+
+    private
+    def default_meta
+      { total: @data.size, count: @data.size, offset: 0 }
+    end
+
+    def prepared_data
+      @data.map do |row|
+        allowed_fields = allowed_fields(row.class)
+        clean_data(attributes_and_associations(row), allowed_fields)
+      end
+    end
+
+    def allowed_fields(klazz, nested = false)
+      nested ? klazz.fastapi_fields_sub : klazz.fastapi_fields + @whitelist
+    end
+
+    def clean_data(entity, allowed_fields)
+      entity.symbolize_keys.slice(*allowed_fields)
+    end
+
+    def attributes_and_associations(row)
+      row.attributes.merge(loaded_associations(row))
+    end
+
+    def loaded_associations(row)
+      row.association_cache.each_with_object({}) do |(name, association), results|
+
+        allowed_fields = allowed_fields(association.klass, true)
+        target         = association.target
+        raw_data       = [*target].map { |element| element.attributes }
+        cleaned_data   = raw_data.map { |data| clean_data(data, allowed_fields) }
+
+        results[name] = cleaned_data
+      end
+    end
+  end
+end

--- a/lib/fastapi/spoof.rb
+++ b/lib/fastapi/spoof.rb
@@ -17,7 +17,7 @@ module FastAPI
 
     private
     def default_meta
-      { total: @data.size, count: @data.size, offset: 0 }
+      { total: @data.size, count: @data.size, offset: 0, error: nil }
     end
 
     def prepared_data

--- a/spec/helpers/model_helper.rb
+++ b/spec/helpers/model_helper.rb
@@ -22,7 +22,7 @@ module ModelHelper
     api = clazz.fastapi
 
     if options.key?(:whitelist)
-      api.whitelist([*options[:whitelist]])
+      api.whitelist(options[:whitelist])
     end
 
     meta = options.key?(:meta) ? options[:meta] : {}

--- a/spec/helpers/model_helper.rb
+++ b/spec/helpers/model_helper.rb
@@ -17,4 +17,18 @@ module ModelHelper
     results = clazz.fastapi.fetch(id)
     Oj.load(results.response)
   end
+
+  def self.spoof!(clazz, data, options = {})
+    api = clazz.fastapi
+
+    if options.key?(:whitelist)
+      api.whitelist([*options[:whitelist]])
+    end
+
+    meta = options.key?(:meta) ? options[:meta] : {}
+
+    results = api.spoof!(data, meta)
+
+    Oj.load(results)
+  end
 end

--- a/spec/person_spec.rb
+++ b/spec/person_spec.rb
@@ -133,4 +133,119 @@ describe Person do
       let(:expected) { { attributes: %w(id name gender age buckets dishes pets) } }
     end
   end
+
+  describe 'when spoofing! without preload' do
+    let!(:person)          { create(:person_with_buckets) }
+    let(:people)           { Person.all }
+    let(:response)         { ModelHelper.spoof!(Person, people) }
+    let(:retrieved_person) { response["data"].first }
+
+    it_behaves_like 'fastapi_meta' do
+      let(:expected) { { total: 1, count: 1, offset: 0, error: false } }
+    end
+
+    it_behaves_like 'fastapi_data' do
+      let(:expected) { { attributes: %w(id name gender age) } }
+    end
+
+    it 'has the correct count' do
+      expect(response["data"].size).to eq 1
+    end
+
+    it 'has the correct id' do
+      expect(retrieved_person["id"]).to eq person.id
+    end
+
+    it 'has the correct name' do
+      expect(retrieved_person["name"]).to eq person.name
+    end
+
+    it 'has the correct gender' do
+      expect(retrieved_person["gender"]).to eq person.gender
+    end
+
+    it 'has the correct age' do
+      expect(retrieved_person["age"]).to eq person.age
+    end
+  end
+
+  describe 'when spoofing! using a whitelist' do
+    let!(:person)          { create(:person_with_buckets) }
+    let(:people)           { Person.all }
+    let(:response)         { ModelHelper.spoof!(Person, people, whitelist: :created_at) }
+    let(:retrieved_person) { response["data"].first }
+
+    it_behaves_like 'fastapi_meta' do
+      let(:expected) { { total: 1, count: 1, offset: 0, error: false } }
+    end
+
+    it_behaves_like 'fastapi_data' do
+      let(:expected) { { attributes: %w(id name gender age created_at) } }
+    end
+  end
+
+  describe 'when spoofing! using preload' do
+    let!(:person)          { create(:person_with_buckets) }
+    let(:people)           { Person.eager_load(:buckets) }
+    let(:response)         { ModelHelper.spoof!(Person, people) }
+    let(:retrieved_person) { response["data"].first }
+
+    it_behaves_like 'fastapi_meta' do
+      let(:expected) { { total: 1, count: 1, offset: 0, error: false } }
+    end
+
+    it_behaves_like 'fastapi_data' do
+      let(:expected) { { attributes: %w(id name gender age buckets) } }
+    end
+
+    it 'has the correct count' do
+      expect(response["data"].size).to eq 1
+    end
+
+    it 'has the correct id' do
+      expect(retrieved_person["id"]).to eq person.id
+    end
+
+    it 'has the correct name' do
+      expect(retrieved_person["name"]).to eq person.name
+    end
+
+    it 'has the correct gender' do
+      expect(retrieved_person["gender"]).to eq person.gender
+    end
+
+    it 'has the correct age' do
+      expect(retrieved_person["age"]).to eq person.age
+    end
+
+    describe 'preloaded buckets' do
+      let(:buckets)             { retrieved_person["buckets"] }
+      let(:associated_bucket)   { buckets.first }
+      let(:actual_first_bucket) { Bucket.find(associated_bucket["id"]) }
+
+      it_behaves_like 'fastapi_data' do
+        let(:expected) { { data: associated_bucket, attributes: %w(id color material used) } }
+      end
+
+      it 'has five buckets' do
+        expect(buckets.size).to eq person.buckets.size
+      end
+
+      it 'the first bucket has the correct id' do
+        expect(associated_bucket["id"]).to eq actual_first_bucket.id
+      end
+
+      it 'the first bucket has the correct color' do
+        expect(associated_bucket["color"]).to eq actual_first_bucket.color
+      end
+
+      it 'the first bucket has the correct material' do
+        expect(associated_bucket["material"]).to eq actual_first_bucket.material
+      end
+
+      it 'the first bucket has the correct used value' do
+        expect(associated_bucket["used"]).to eq actual_first_bucket.used
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Adding advanced spoofing

###### Spoof vs Spoof!

`spoof`'s functionality remains the same, but `spoof!` performs FastAPI filtering, whitelisting, and handles preloaded associations.

* Created a new class to handle spoofing.
  * Accepts ActiveRecord data and overriding meta data.
* `spoof!` includes related data if it is in the
  allowed fields or whitelist, and has been preloaded.

###### Created advanced spoofing tests.
* Added a `spoof!` method to ModelHelper.

###### Miscellaneous
* Fix overriding meta.
* Adding a blank error message to the default meta.