### PR TITLE
Handle nil/[] in multi-value comparisons.

### DIFF
--- a/lib/fastapi/comparison.rb
+++ b/lib/fastapi/comparison.rb
@@ -82,8 +82,12 @@ module FastAPI
     end
 
     def multi_sql(clause, value, field, type)
-      values = [*value].map { |v| ActiveRecord::Base.connection.quote(v) }.join(',')
-      [clause.sub('__FIELD__', field).sub('__VALUES__', values).sub('__TYPE__', @@types[type])].compact.join
+      if value.nil? || value.empty?
+        '1 = 0'
+      else
+        values = [*value].map { |v| ActiveRecord::Base.connection.quote(v) }.join(',')
+        [clause.sub('__FIELD__', field).sub('__VALUES__', values).sub('__TYPE__', @@types[type])].compact.join
+      end
     end
   end
 end

--- a/spec/pet_spec.rb
+++ b/spec/pet_spec.rb
@@ -81,5 +81,31 @@ describe Pet do
         let(:expected) { { data: pet_from_person, attributes: %w(peoples_pets_id name color) } }
       end
     end
+
+    describe 'when locating a pet using a multi-value comparison and an empty array' do
+      let!(:pet)     { create(:pet) }
+      let(:response) { ModelHelper.response(Pet, peoples_pets_id__in: []) }
+
+      it_behaves_like 'fastapi_meta' do
+        let(:expected) { { total: 0, count: 0, offset: 0, error: false } }
+      end
+
+      it 'has an empty data array' do
+        expect(response['data']).to eq []
+      end
+    end
+
+    describe 'when locating a pet using a multi-value comparison and nil' do
+      let!(:pet)     { create(:pet) }
+      let(:response) { ModelHelper.response(Pet, peoples_pets_id__in: nil) }
+
+      it_behaves_like 'fastapi_meta' do
+        let(:expected) { { total: 0, count: 0, offset: 0, error: false } }
+      end
+
+      it 'has an empty data array' do
+        expect(response['data']).to eq []
+      end
+    end
   end
 end


### PR DESCRIPTION
* Follow how ActiveRecord handles empty arrays for multi-value
  comparisons.

```
>> Listing.where(id: [])
   Listing Load (0.8ms)  SELECT "listings".* FROM "listings" WHERE 1=0
```

* Adding tests to cover this functionality.