### PR TITLE
Fix singular associations

### DIFF
--- a/lib/fastapi/spoof.rb
+++ b/lib/fastapi/spoof.rb
@@ -53,7 +53,7 @@ module FastAPI
     def retrieved_attributes(target, allowed_fields)
       if target.respond_to?(:map)
         target.map { |element| clean_data(element.attributes, allowed_fields) }
-      else
+      elsif target.present?
         clean_data(target.attributes, allowed_fields)
       end
     end

--- a/lib/fastapi/spoof.rb
+++ b/lib/fastapi/spoof.rb
@@ -43,13 +43,18 @@ module FastAPI
 
     def loaded_associations(row)
       row.association_cache.each_with_object({}) do |(name, association), results|
-
         allowed_fields = allowed_fields(association.klass, true)
         target         = association.target
-        raw_data       = [*target].map { |element| element.attributes }
-        cleaned_data   = raw_data.map { |data| clean_data(data, allowed_fields) }
 
-        results[name] = cleaned_data
+        results[name] = retrieved_attributes(target, allowed_fields)
+      end
+    end
+
+    def retrieved_attributes(target, allowed_fields)
+      if target.respond_to?(:map)
+        target.map { |element| clean_data(element.attributes, allowed_fields) }
+      else
+        clean_data(target.attributes, allowed_fields)
       end
     end
   end

--- a/lib/fastapi/sql.rb
+++ b/lib/fastapi/sql.rb
@@ -104,10 +104,7 @@ module FastAPI
           end
         end
 
-        # fields
         if model_data[:type] == :belongs_to
-
-          # joins
           join_list << %(LEFT JOIN "#{table_name}" AS "#{association_name}" ON "#{parent_table_name}"."#{foreign_key}" = "#{association_name}"."#{primary_key}")
         elsif model_data[:type] == :has_one
           join_list << %(LEFT JOIN "#{table_name}" AS "#{association_name}" ON "#{association_name}"."#{foreign_key}" = "#{parent_table_name}"."#{parent_primary_key}")

--- a/spec/dish_spec.rb
+++ b/spec/dish_spec.rb
@@ -82,4 +82,15 @@ describe Dish do
       expect(beverage).to_not be_instance_of(Array)
     end
   end
+
+  describe 'when spoofing! using preload on a has_one relationship that is nil' do
+    let!(:dish)    { create(:burrito) }
+    let(:burrito)  { Dish.eager_load(:beverage) }
+    let(:response) { ModelHelper.spoof!(Dish, burrito) }
+    let(:beverage) { response['data'].first['beverage'] }
+
+    it 'the beverage is nil' do
+      expect(beverage).to be_nil
+    end
+  end
 end

--- a/spec/dish_spec.rb
+++ b/spec/dish_spec.rb
@@ -67,4 +67,19 @@ describe Dish do
       expect(beverage['flavors'].sort).to eq %w(sweet vanilla cinnamon orange lime lemon nutmeg).sort
     end
   end
+
+  describe 'when spoofing! using preload on a has_one relationship' do
+    let!(:dish)    { create(:burrito_with_coke) }
+    let(:burrito)  { Dish.eager_load(:beverage) }
+    let(:response) { ModelHelper.spoof!(Dish, burrito) }
+    let(:beverage) { response['data'].first['beverage'] }
+
+    it 'has a beverage' do
+      expect(beverage).to be_instance_of(Hash)
+    end
+
+    it 'does not have an array containing a beverage' do
+      expect(beverage).to_not be_instance_of(Array)
+    end
+  end
 end

--- a/spec/person_spec.rb
+++ b/spec/person_spec.rb
@@ -152,7 +152,7 @@ describe Person do
   describe 'when spoofing! a single model' do
     let!(:person)          { create(:person_with_buckets) }
     let(:response)         { ModelHelper.spoof!(Person, person) }
-    let(:retrieved_person) { response["data"].first }
+    let(:retrieved_person) { response['data'].first }
 
     it_behaves_like 'fastapi_meta' do
       let(:expected) { { total: 1, count: 1, offset: 0, error: false } }
@@ -163,23 +163,23 @@ describe Person do
     end
 
     it 'has the correct count' do
-      expect(response["data"].size).to eq 1
+      expect(response['data'].size).to eq 1
     end
 
     it 'has the correct id' do
-      expect(retrieved_person["id"]).to eq person.id
+      expect(retrieved_person['id']).to eq person.id
     end
 
     it 'has the correct name' do
-      expect(retrieved_person["name"]).to eq person.name
+      expect(retrieved_person['name']).to eq person.name
     end
 
     it 'has the correct gender' do
-      expect(retrieved_person["gender"]).to eq person.gender
+      expect(retrieved_person['gender']).to eq person.gender
     end
 
     it 'has the correct age' do
-      expect(retrieved_person["age"]).to eq person.age
+      expect(retrieved_person['age']).to eq person.age
     end
   end
 
@@ -187,7 +187,7 @@ describe Person do
     let!(:person)          { create(:person_with_buckets) }
     let(:people)           { Person.all }
     let(:response)         { ModelHelper.spoof!(Person, people) }
-    let(:retrieved_person) { response["data"].first }
+    let(:retrieved_person) { response['data'].first }
 
     it_behaves_like 'fastapi_meta' do
       let(:expected) { { total: 1, count: 1, offset: 0, error: false } }
@@ -198,23 +198,23 @@ describe Person do
     end
 
     it 'has the correct count' do
-      expect(response["data"].size).to eq 1
+      expect(response['data'].size).to eq 1
     end
 
     it 'has the correct id' do
-      expect(retrieved_person["id"]).to eq person.id
+      expect(retrieved_person['id']).to eq person.id
     end
 
     it 'has the correct name' do
-      expect(retrieved_person["name"]).to eq person.name
+      expect(retrieved_person['name']).to eq person.name
     end
 
     it 'has the correct gender' do
-      expect(retrieved_person["gender"]).to eq person.gender
+      expect(retrieved_person['gender']).to eq person.gender
     end
 
     it 'has the correct age' do
-      expect(retrieved_person["age"]).to eq person.age
+      expect(retrieved_person['age']).to eq person.age
     end
   end
 
@@ -222,7 +222,7 @@ describe Person do
     let!(:person)          { create(:person_with_buckets) }
     let(:people)           { Person.all }
     let(:response)         { ModelHelper.spoof!(Person, people, whitelist: :created_at) }
-    let(:retrieved_person) { response["data"].first }
+    let(:retrieved_person) { response['data'].first }
 
     it_behaves_like 'fastapi_meta' do
       let(:expected) { { total: 1, count: 1, offset: 0, error: false } }
@@ -237,7 +237,7 @@ describe Person do
     let!(:person)          { create(:person_with_buckets) }
     let(:people)           { Person.eager_load(:buckets) }
     let(:response)         { ModelHelper.spoof!(Person, people) }
-    let(:retrieved_person) { response["data"].first }
+    let(:retrieved_person) { response['data'].first }
 
     it_behaves_like 'fastapi_meta' do
       let(:expected) { { total: 1, count: 1, offset: 0, error: false } }
@@ -248,29 +248,29 @@ describe Person do
     end
 
     it 'has the correct count' do
-      expect(response["data"].size).to eq 1
+      expect(response['data'].size).to eq 1
     end
 
     it 'has the correct id' do
-      expect(retrieved_person["id"]).to eq person.id
+      expect(retrieved_person['id']).to eq person.id
     end
 
     it 'has the correct name' do
-      expect(retrieved_person["name"]).to eq person.name
+      expect(retrieved_person['name']).to eq person.name
     end
 
     it 'has the correct gender' do
-      expect(retrieved_person["gender"]).to eq person.gender
+      expect(retrieved_person['gender']).to eq person.gender
     end
 
     it 'has the correct age' do
-      expect(retrieved_person["age"]).to eq person.age
+      expect(retrieved_person['age']).to eq person.age
     end
 
     describe 'preloaded buckets' do
-      let(:buckets)             { retrieved_person["buckets"] }
+      let(:buckets)             { retrieved_person['buckets'] }
       let(:associated_bucket)   { buckets.first }
-      let(:actual_first_bucket) { Bucket.find(associated_bucket["id"]) }
+      let(:actual_first_bucket) { Bucket.find(associated_bucket['id']) }
 
       it_behaves_like 'fastapi_data' do
         let(:expected) { { data: associated_bucket, attributes: %w(id color material used) } }
@@ -281,19 +281,19 @@ describe Person do
       end
 
       it 'the first bucket has the correct id' do
-        expect(associated_bucket["id"]).to eq actual_first_bucket.id
+        expect(associated_bucket['id']).to eq actual_first_bucket.id
       end
 
       it 'the first bucket has the correct color' do
-        expect(associated_bucket["color"]).to eq actual_first_bucket.color
+        expect(associated_bucket['color']).to eq actual_first_bucket.color
       end
 
       it 'the first bucket has the correct material' do
-        expect(associated_bucket["material"]).to eq actual_first_bucket.material
+        expect(associated_bucket['material']).to eq actual_first_bucket.material
       end
 
       it 'the first bucket has the correct used value' do
-        expect(associated_bucket["used"]).to eq actual_first_bucket.used
+        expect(associated_bucket['used']).to eq actual_first_bucket.used
       end
     end
   end


### PR DESCRIPTION
Correctly spoof singular associations.
* Should not return an array of one element, just the element.
* Added relevant tests.